### PR TITLE
Fix crash when running mud with no arguments (issue #90)

### DIFF
--- a/src/mud/app.py
+++ b/src/mud/app.py
@@ -35,7 +35,10 @@ class App:
 
 	@staticmethod
 	def _create_parser() -> ArgumentParser:
-		parser = ArgumentParser(description=f'mud allows you to run commands in multiple repositories.')
+		parser = ArgumentParser(
+			description=f'mud allows you to run commands in multiple repositories.',
+			usage='%(prog)s [OPTIONS] [COMMAND] ...',
+		)
 		subparsers = parser.add_subparsers(dest='command')
 
 		subparsers.add_parser(LOG[0], aliases=LOG[1:], help='Displays log of latest commit messages for all repositories in a table view.')
@@ -130,7 +133,7 @@ class App:
 
 		# Handling commands
 		if native_command:
-			args = self.parser.parse_args()
+			args, _ = self.parser.parse_known_args()
 
 			if args.command in INIT + ADD + REMOVE + PRUNE + GET_CONFIG:
 				if args.command in GET_CONFIG:

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -8,6 +8,20 @@ from pathlib import Path
 from helpers import run_mud
 
 
+def test_no_args_shows_help(tmp_path: Path, home: Path):
+	"""mud with no arguments must print help without raising an exception (issue #90).
+
+	This crashed on Python 3.12 with an AssertionError inside argparse._format_usage
+	because the auto-generated usage string was too long and triggered a buggy
+	regex-based wrapping assertion.  The fix is to supply a custom usage= string
+	to ArgumentParser so that assertion is never reached.
+	"""
+	result = run_mud(cwd=tmp_path, home=home)
+	assert result.returncode == 0, f"mud with no args exited {result.returncode}:\n{result.stderr}"
+	# Should mention key commands in the help output
+	assert "mud" in result.stdout or "mud" in result.stderr
+
+
 def test_status(repos: Path, home: Path):
 	result = run_mud("status", cwd=repos, home=home)
 	assert result.returncode == 0


### PR DESCRIPTION
## Problem

Running `mud` with no arguments crashed on Python 3.12 with an `AssertionError` inside `argparse._format_usage`:

```
AssertionError
  File ".../argparse.py", line 355, in _format_usage
      assert ' '.join(pos_parts) == pos_usage
```

## Root cause

Python 3.12's `argparse._format_usage` has a sanity assertion that is only reached when the auto-generated usage string is **too long to fit on one line**. With mud's many subcommands (each with aliases), filter flags, and the `catch_all` positional, the usage string always exceeds the terminal width — so the assertion code always ran and always failed on 3.12.

## Fix

**`src/mud/app.py`**

1. Pass `usage='%(prog)s [OPTIONS] [COMMAND] ...'` to `ArgumentParser`. When an explicit `usage=` is provided, `_format_usage` uses it directly and never enters the auto-generation/assertion code path.

2. Replace `parse_args()` with `parse_known_args()` in native-command mode. Filter flags (e.g. `-l=myLabel`) can still be in `sys.argv` when the parser runs; `parse_known_args` tolerates unrecognized tokens instead of raising an error.

**`tests/test_display.py`**

Adds `test_no_args_shows_help` — a regression test that runs `mud` with zero arguments and asserts exit code 0 and no exception, exactly matching the scenario from issue #90.

Closes #90