### PR TITLE
Fix trailing slash on mud add and omit trailing tab when no labels

### DIFF
--- a/src/mud/config.py
+++ b/src/mud/config.py
@@ -41,8 +41,10 @@ class Config:
 
 			for path, labels in self.data.items():
 				valid_labels = [label for label in labels if _filter_labels(label)]
-				formatted_labels = ','.join(valid_labels) if valid_labels else ''
-				writer.writerow([path, formatted_labels])
+				if valid_labels:
+					writer.writerow([path, ','.join(valid_labels)])
+				else:
+					writer.writerow([path])
 
 	def load(self, file_path: str) -> None:
 		self.data = {}
@@ -108,6 +110,8 @@ class Config:
 
 			config_path = os.path.join(config_dir, utils.CONFIG_FILE_NAME)
 			path = os.path.relpath(current_path, config_path)
+		if path is not None:
+			path = path.rstrip('/')
 		if path is None:
 			path = label
 			label = None


### PR DESCRIPTION
## Changes

### Fix trailing `/` on `mud add <PATH>` (closes #109)
Shell tab-completion often appends a trailing slash to directory paths. `Config.add()` now calls `path.rstrip('/')` so the path is stored cleanly regardless of whether the user typed the slash or the shell added it.

### Omit trailing `\t` in `.mudconfig` when a repo has no labels
`Config.save()` now writes a single-column row (`<PATH>\n`) for repos without labels instead of the previous two-column row (`<PATH>\t\n`). `Config.load()` already handled rows with a missing second column, so no changes were needed on the read side.